### PR TITLE
Add endpoint to URL, minor fixes, important comments, and URL update

### DIFF
--- a/examples/01_TTS/node/tts_flite.js
+++ b/examples/01_TTS/node/tts_flite.js
@@ -1,7 +1,7 @@
 // Example TTS - "flite"
 
 // To install "flite" please see Tech Resources:
-// https://github.com/juxtapix/ExpressiveInterfaces_Voice/wiki/01.-TTS#technical-resources
+// https://github.com/juxtapix/OkRobotReboot/wiki/02.-TTS#technical-resources
 
 // require "child_process" to run Child Process Applications
 var exec = require('child_process').execSync;

--- a/examples/01_TTS/python/tts_flite.py
+++ b/examples/01_TTS/python/tts_flite.py
@@ -1,7 +1,7 @@
 # Example TTS - "flite"
 
 # To install flite please see Tech Resources:
-# https://github.com/juxtapix/ExpressiveInterfaces_Voice/wiki/01.-TTS#technical-resources
+# https://github.com/juxtapix/OkRobotReboot/wiki/02.-TTS#technical-resources
 
 # import "os" to access operating system functionalities
 import os

--- a/examples/02_STT/node/stt_watson_json.js
+++ b/examples/02_STT/node/stt_watson_json.js
@@ -6,7 +6,8 @@ var request = require('request');
 
 function listen(something){
   var APIkey = "YOUR_API_KEY";
-  var url = "YOUR_API_URL";
+  var endpoint = "/v1/recognize?timestamps=true&max_alternatives=3"
+  var url = "YOUR_API_URL" + endpoint;
   var auth = 'Basic ' + Buffer.from('apikey:' + APIkey).toString('base64');
   var data =  Buffer.from(fs.readFileSync(something));
   var options = {

--- a/examples/02_STT/node/stt_watson_ws.js
+++ b/examples/02_STT/node/stt_watson_ws.js
@@ -6,7 +6,8 @@ var WebSocket = require('ws');
 
 
 var APIkey = "YOUR_API_KEY";
-var url = "YOUR_API_URL";
+var endpoint = "/v1/recognize?timestamps=true&max_alternatives=3"
+var url = "YOUR_API_URL" + endpoint;
 var auth = 'Basic ' + Buffer.from('apikey:' + APIkey).toString('base64');
 
 var options = {

--- a/examples/02_STT/python/stt_watson_json.py
+++ b/examples/02_STT/python/stt_watson_json.py
@@ -1,4 +1,9 @@
 # Example STT - "watson JSON"
+# --- either ---
+# sudo pip install requests
+# --- or ---
+# python3 -m venv .venv
+# source .venv/bin/activate
 # pip install requests
 
 import sys
@@ -7,10 +12,12 @@ import requests
 
 def listen(something):
     APIkey = 'YOUR_API_KEY'
-    url = 'YOUR_API_URL'
+    endpoint = '/v1/recognize?timestamps=true&max_alternatives=3'
+    url = 'YOUR_API_URL' + endpoint
     data = open(something, 'rb').read()
-    auth = 'Basic ' + base64.b64encode('apikey:' + APIkey)
-    headers = {'Content-Type': 'audio/flac', 'Authorization': auth}
+    auth = 'apikey:' + APIkey
+    headers = {'Content-Type': 'audio/flac', 'Authorization': 'Basic ' + base64.b64encode(
+        auth.encode()).decode()}
     r = requests.post(headers=headers, url=url, data=data)
     with open("watson.json", "a") as myfile:
         myfile.write(r.text)

--- a/examples/02_STT/python/stt_watson_mic.py
+++ b/examples/02_STT/python/stt_watson_mic.py
@@ -1,7 +1,23 @@
 # Example STT - "watson streaming"
 # Modified example from "ibm-dev/watson-streaming-stt"
-# pip install websocket_client
+# --- windows only ---
+# pip install pipwin
+# pipwin install pyaudio
+# --------------------
+# --- mac only ---
+# xcode-select --install
+# brew install portaudio
+# ----------------
+# python3 -m venv .venv
+# source .venv/bin/activate
 # pip install pyaudio
+# pip install websocket_client
+# --- mac only ---
+# it is recommended to run this particular piece of python code with either Terminal or iTerm2(if you prefer)
+# allow microphone access if prompted
+# running this piece of python code in VSCode integrated terminal will not work unless running with VSCode with sudo (not recommended)
+# sudo /Applications/Visual\ Studio\ Code.app/Contents/MacOS/Electron
+# ----------------
 
 import os
 import sys
@@ -64,6 +80,8 @@ def on_message(ws, message):
         print(data['results'][0]['alternatives'][0]['transcript'])
         done = {"action": "stop"}
         ws.send(json.dumps(done).encode('utf8'))
+    elif "error" in data:
+        print(data['error']) 
 
 def on_error(ws, error):
     print(error)
@@ -89,7 +107,9 @@ def on_open(ws):
 def connect():
     # websocket.enableTrace(True)
     APIkey = "YOUR_API_KEY"
-    url = "YOUR_API_URL"
+    endpoint = "/v1/recognize?timestamps=true&max_alternatives=3"
+    # wss instead of https for YOUR_API_URL
+    url = "YOUR_API_URL" + endpoint
     headers = {}
     auth = "apikey:" + APIkey
     headers["Authorization"] = "Basic " + base64.b64encode(

--- a/examples/02_STT/python/stt_watson_ws.py
+++ b/examples/02_STT/python/stt_watson_ws.py
@@ -44,7 +44,9 @@ def on_open(ws):
 def connect():
     # websocket.enableTrace(True)
     APIkey = "YOUR_API_KEY"
-    url = "YOUR_API_URL"
+    endpoint = "/v1/recognize?timestamps=true&max_alternatives=3"
+    # wss instead of https for YOUR_API_URL
+    url = "YOUR_API_URL" + endpoint
     headers = {}
     auth = "apikey:" + APIkey
     headers["Authorization"] = "Basic " + base64.b64encode(


### PR DESCRIPTION
added endpoint to url for all the modified files;
fixed auth error in python watson json example;
added installation comments for python watson mic example;
minor update of two same URLs in the comments of both flite node and python examples, which takes it back to the GitHub Wiki link with the new repository name and page name